### PR TITLE
properly merge less than 3% archetypes into other

### DIFF
--- a/scripts/ladderClass.js
+++ b/scripts/ladderClass.js
@@ -130,10 +130,11 @@ class Ladder {
                 // Merge
                 if (fr < this.fr_min && i>8) {
                     this.traces.bar.decks[classIdx].y[rank] += fr
-                    fr = 0
                 }
-                fr_avg += fr
-                archFr.push(fr)
+                else {
+                    fr_avg += fr
+                    archFr.push(fr)
+                }
                 
                 for (let bracket of this.rankBrackets) {
                     if (rank == bracket.start) {


### PR DESCRIPTION
setting fr to 0 creates the bug further down with pie chart because the real fr value is lost and cannot be merged into other